### PR TITLE
Let tests work on fresh docker-compose for localdev

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,22 @@ All python in this project is auto-formatted using `black` with a line length of
 Obviously, adjust your blackPath as necessary.
 
 ## Requirements
+
 I develop on a Mac, but this stuff should all work on any operating system that can run docker and docker-compose.
+
+## Running tests
+
+If you're using docker-compose for local development, the following commands should work out of the box
+
+```sh
+# Run the stack so mysql is available
+docker-compose up -d
+
+# Run the tests
+docker-compose exec web bash -c 'python manage.py test'
+```
+
+The django test framework tries to make a `test_esdkp` database, so MySQL is provided a startup script in `local-init.sql` that will add the needed permissions to the user specified in `localdev.env` so that Django's test framework can run.
 
 ## Seeding Fixture Data
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,7 @@ services:
       - localdev.env
     volumes:
       - esdkp-mysql:/var/lib/mysql
+      - ./local-init.sql:/docker-entrypoint-initdb.d/local-init.sql
 
   web:
     restart: always

--- a/local-init.sql
+++ b/local-init.sql
@@ -1,0 +1,2 @@
+GRANT USAGE on *.* to esdkp;
+GRANT ALL on test_esdkp.* to esdkp;


### PR DESCRIPTION
The default user was unable to create a test database.

Added permissions script to mysql to work with our localdev.env settings that allows testing to work. See the updates to README.md for more info.